### PR TITLE
Fixed netaddr.EUI accepting EUI_64 addresses (which are not MAC addresses)

### DIFF
--- a/macaddress/fields.py
+++ b/macaddress/fields.py
@@ -49,7 +49,7 @@ class MACAddressField(with_metaclass(models.SubfieldBase, models.Field)):
         if value is None:
             return None
         if not isinstance(value, EUI):
-            value = EUI(value, dialect=default_dialect())
+            value = EUI(value, version=48, dialect=default_dialect())
             if self.integer:
                 return int(value)
             return str(value)
@@ -70,7 +70,7 @@ class MACAddressField(with_metaclass(models.SubfieldBase, models.Field)):
             value.dialect = default_dialect(value)
             return value
         try:
-            return EUI(value, dialect=default_dialect())
+            return EUI(value, version=48, dialect=default_dialect())
         except (TypeError, ValueError, AddrFormatError):
             raise ValidationError(
                 "This value must be a valid MAC address.")

--- a/macaddress/fields.py
+++ b/macaddress/fields.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.six import with_metaclass
 
 from netaddr import EUI, AddrFormatError
 
@@ -10,7 +9,7 @@ from . import default_dialect, format_mac, mac_linux
 
 import warnings
 
-class MACAddressField(with_metaclass(models.SubfieldBase, models.Field)):
+class MACAddressField(models.Field):
     description = "A MAC address validated by netaddr.EUI"
     empty_strings_allowed = False
     dialect = None
@@ -62,6 +61,9 @@ class MACAddressField(with_metaclass(models.SubfieldBase, models.Field)):
         if self.integer:
             return 'BigIntegerField'
         return 'CharField'
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
             
     def to_python(self, value):
         if value is None:

--- a/macaddress/fields.py
+++ b/macaddress/fields.py
@@ -1,3 +1,4 @@
+import django
 from django.core.exceptions import ValidationError
 from django.db import models
 
@@ -100,6 +101,10 @@ class MACAddressField(models.Field):
                 return None
         else:
             raise TypeError('Lookup type %r not supported.' % lookup_type)
+
+if django.VERSION < (1, 8):
+    from django.utils.six import add_metaclass
+    MACAddressField = add_metaclass(models.SubfieldBase)(MACAddressField)
 
 try:
     from south.modelsinspector import add_introspection_rules

--- a/macaddress/fields.py
+++ b/macaddress/fields.py
@@ -48,7 +48,7 @@ class MACAddressField(models.Field):
         if value is None:
             return None
         if not isinstance(value, EUI):
-            value = EUI(value, version=48, dialect=default_dialect())
+            value = self.to_python(value)
             if self.integer:
                 return int(value)
             return str(value)

--- a/macaddress/formfields.py
+++ b/macaddress/formfields.py
@@ -23,7 +23,7 @@ class MACAddressField(Field):
         if value in EMPTY_VALUES:
             return None
         try:
-            value = EUI(str(value))
+            value = EUI(str(value), version=48)
         except (ValueError, TypeError, AddrFormatError):
             raise ValidationError(self.error_messages['invalid'])
         return value

--- a/macaddress/tests/test_fields.py
+++ b/macaddress/tests/test_fields.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.db import transaction
 
 from netaddr.core import AddrFormatError
 
@@ -23,8 +24,9 @@ class MACAddressFieldTestCase(TestCase):
 
     def test_insert_invalid_macaddress(self):
         invalid_mac = 'XX'
-        x = self.model()
-        with self.assertRaises(ValidationError):
-            x.mac = invalid_mac
-            x.save()
+        with transaction.atomic():
+            x = self.model()
+            with self.assertRaises(ValidationError):
+                x.mac = invalid_mac
+                x.save()
         self.assertEquals(NetworkThingy.objects.all().count(), 0)


### PR DESCRIPTION
It was then unable to insert them in database.
The following fix just makes the form validation refuse EUI 64 addresses (EUI throws an AddrFormatError)