### PR TITLE
Use the official notation of the Django package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     maintainer_email = 'the1.arun@gmail.com',
     packages = ['macaddress', 'macaddress.tests'],
     install_requires = ['netaddr'],
-    tests_require = ['django'],
+    tests_require = ['Django'],
     test_suite="runtests.runtests",
 
     classifiers = [


### PR DESCRIPTION
Even if pypi is case insensitive, all other packages include django with an uppercase D.
This package using lowercase will lead to uninstalls/reinstalls when using pip-compile and other tools.
Please accept the change to make it compatible.