### PR TITLE
add classifiers for packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )


### PR DESCRIPTION
this simplifies python support detection (e.g. for [pypi2deb](https://github.com/p1otr/pypi2deb))