### PR TITLE
Fix EMPTY_VALUES import location

### DIFF
--- a/macaddress/formfields.py
+++ b/macaddress/formfields.py
@@ -1,5 +1,5 @@
 from django.forms import Field
-from django.forms.fields import EMPTY_VALUES
+from django.core.validators import EMPTY_VALUES
 from django.utils.translation import ugettext_lazy as _
 #"From Django 1.8: The django.forms.util module has been renamed. Use django.forms.utils instead."
 try:


### PR DESCRIPTION
EMPTY_VALUES is no longer imported into django.forms.fields in Django 3.1
It is however originally from django.core.validators so use it from there.