### PR TITLE
Get rid of ugettext*

### DIFF
--- a/macaddress/formfields.py
+++ b/macaddress/formfields.py
@@ -1,7 +1,7 @@
 from django.core.validators import EMPTY_VALUES
 from django.forms import Field
 from django.forms.utils import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from netaddr import EUI, AddrFormatError
 


### PR DESCRIPTION
As support for Python 2 has been dropped, the library should not rely on ugettext* anymore but can use gettext* variants.
ugettext* have been deprecated in Django 3.0 and will be removed in Django 4.0.